### PR TITLE
Fix assertion failures in std::slice::from_raw_parts due to null pointers.

### DIFF
--- a/src/addr_validate.rs
+++ b/src/addr_validate.rs
@@ -71,6 +71,10 @@ fn open_pipe() -> nix::Result<()> {
 pub fn validate(addr: *const libc::c_void) -> bool {
     const CHECK_LENGTH: usize = 2 * size_of::<*const libc::c_void>() / size_of::<u8>();
 
+    if addr.is_null() {
+        return false;
+    }
+
     // read data in the pipe
     let read_fd = MEM_VALIDATE_PIPE.read_fd.load(Ordering::SeqCst);
     let valid_read = loop {

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -220,6 +220,10 @@ impl<'a, T> Iterator for TempFdArrayIterator<'a, T> {
             self.index += 1;
             Some(&self.buffer[self.index - 1])
         } else {
+            if self.file_vec.is_empty() {
+                return None;
+            }
+
             let length = self.file_vec.len() / std::mem::size_of::<T>();
             let ts =
                 unsafe { std::slice::from_raw_parts(self.file_vec.as_ptr() as *const T, length) };


### PR DESCRIPTION
Using this library on macOS these days triggers some debug assertions in `std::slice::from_raw_parts()` due to missing null pointer checks.

Adding two such checks - one explicitly checking for a null pointer, the other ensuring that a `Vec` is non-empty (i.e.: has allocated some memory on the heap and holds a pointer to it) - fixes the assertion failures.